### PR TITLE
過去日本で実施されたサマータイムが影響するのでテストデータを変更 

### DIFF
--- a/src/test/java/nablarch/integration/jsr310/beans/converter/LocalDateConverterTest.java
+++ b/src/test/java/nablarch/integration/jsr310/beans/converter/LocalDateConverterTest.java
@@ -39,7 +39,7 @@ public class LocalDateConverterTest {
                 {LocalDateTime.of(2017, 6, 13, 12, 30, 15), LocalDate.of(2017, 6, 13)},
                 {DateUtil.getParsedDate("20170621000000000", "yyyyMMddHHmmssSSS"), LocalDate.of(2017, 6, 21)},
                 {DateUtil.getParsedDate("20170622235011300", "yyyyMMddHHmmssSSS"), LocalDate.of(2017, 6, 22)},
-                {newSqlDate("19490403000000", "yyyyMMddHHmmss"), LocalDate.of(1949, 4, 3)}
+                {newSqlDate("19490402000000", "yyyyMMddHHmmss"), LocalDate.of(1949, 4, 2)}
         };
 
         @Theory

--- a/src/test/java/nablarch/integration/jsr310/util/DateTimeUtilTest.java
+++ b/src/test/java/nablarch/integration/jsr310/util/DateTimeUtilTest.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.DateUtil;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,6 +26,11 @@ public class DateTimeUtilTest {
 
     @Before
     public void setUp() throws Exception {
+        SystemRepository.clear();
+    }
+
+    @After
+    public void tearDown() throws Exception {
         SystemRepository.clear();
     }
 


### PR DESCRIPTION
https://ja.wikipedia.org/wiki/%E5%A4%8F%E6%99%82%E9%96%93#%E6%97%A5%E6%9C%AC%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E5%A4%8F%E6%99%82%E9%96%93

> 日本において夏時間は、第二次世界大戦敗北後の連合国軍占領期にGHQ指導下で公的に導入され、1948年（昭和23年）4月28日に公布された夏時刻法に基づき、同年5月2日の午前0時から9月11日にかけて初めて実施された
> 以後、毎年5月（ただし、1949年（昭和24年）のみ4月）第1土曜日24時（= 日曜日0時）から9月第2土曜日25時（= 日曜日0時）までの間に夏時間が実施されることとなったが、

1949年4月3日は第1土曜日の翌日のためサマータイム期間に該当する。
そのため`DateTime.parse`で`HH`に該当する`00`をパースできず、テストデータの準備に失敗する。

サマータイム期間に該当しない日付に変更することで対応した。